### PR TITLE
D73-10 | Get the activity groups from the API and display them

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+API_BASE_URL=

--- a/app.vue
+++ b/app.vue
@@ -1,6 +1,3 @@
 <template>
-  <div>
-    <NuxtRouteAnnouncer />
-    <NuxtWelcome />
-  </div>
+    <ActivityGroups />
 </template>

--- a/components/ActivityGroups.vue
+++ b/components/ActivityGroups.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { ActivityGroup } from '~/types/activityGroup';
+import { getActivityGroups } from '~/composables/getActivityGroups';
+
+const activityGroups = ref<ActivityGroup[]>([]);
+const error = ref<string | null>(null);
+
+onMounted(async () => {
+    try {
+        activityGroups.value = await getActivityGroups();
+    } catch (err) {
+        error.value = (err as Error).message;
+    }
+});
+</script>
+
+<template>
+    <div>
+        <h1>Activity Groups</h1>
+        <div v-for="group in activityGroups">
+            <ul>
+                <li>
+                    <strong>ID: </strong>
+                    {{ group.id }}
+                </li>
+                <li>
+                    <strong>Activity Group: </strong>
+                    {{group.name}}
+                </li>
+                <li>
+                    <strong>Description:</strong>
+                    {{ group.description }}
+                </li>
+                <li>
+                    <strong>Status</strong>
+                    {{ group.status }}
+                </li>
+                <hr>
+            </ul>
+        </div>
+    </div>
+</template>
+
+
+
+
+
+
+
+

--- a/composables/getActivityGroups.ts
+++ b/composables/getActivityGroups.ts
@@ -1,0 +1,10 @@
+import { type ActivityGroup } from "~/types/ActivityGroup";
+
+export const getActivityGroups = async (): Promise<ActivityGroup[]> => {
+    try {
+        const config = useRuntimeConfig();
+        return await $fetch<ActivityGroup[]>(`${config.public.apiBaseUrl}/activity-groups`);
+    } catch (error) {
+        throw new Error("Failed to load activity groups:");
+    }
+};

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,10 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2024-04-03',
-  devtools: { enabled: true }
+  devtools: { enabled: true },
+  runtimeConfig: {
+    public: {
+      apiBaseUrl: process.env.API_BASE_URL,
+    },
+  },
 })

--- a/types/ActivityGroup.ts
+++ b/types/ActivityGroup.ts
@@ -1,0 +1,6 @@
+export interface ActivityGroup {
+    id: number;
+    name: string;
+    description: string;
+    status: string;
+}


### PR DESCRIPTION
# [D73-10] | Install a base Nuxt application
- Epic: [D73-16]

## Work
Call the API to GET all activity groups and display them on the base application page (unstyled).

## Testing
- Visit http://localhost:3000/

### Acceptance Criteria 1 
**WHEN** I have added an activity to the database
**AND** I view the base application page
**THEN** I see a list of activity groups, including the `ID`, `name`, `description` and `status`.

[D73-10]: https://rheannemcintosh.atlassian.net/browse/D73-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D73-16]: https://rheannemcintosh.atlassian.net/browse/D73-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ