### PR TITLE
D73-12 | Create an Activity Group

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,3 +1,4 @@
 <template>
     <ActivityGroups />
+    <CreateActivityGroup />
 </template>

--- a/components/CreateActivityGroup.vue
+++ b/components/CreateActivityGroup.vue
@@ -1,0 +1,106 @@
+<template>
+    <div>
+        <h1>Create Activity Group</h1>
+        <form @submit.prevent="submitForm">
+            <div>
+                <label for="name">Name:</label>
+                <input type="text" v-model="form.name" id="name" />
+            </div>
+            <div>
+                <label for="description">Description:</label>
+                <input type="text" v-model="form.description" id="description" />
+            </div>
+            <div>
+                <label for="status">Status:</label>
+                <select v-model="form.status" id="status">
+                    <option value="" disabled>Please Select</option>
+                    <option value="To Do">To Do</option>
+                    <option value="In Progress">In Progress</option>
+                    <option value="Done">Done</option>
+                </select>
+            </div>
+            <button type="submit">Create Activity Group</button>
+        </form>
+
+        <div v-if="error" class="error">
+            <p>{{ error }}</p>
+        </div>
+        <div v-if="successMessage" class="success">
+            <p>{{ successMessage }}</p>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+    import { ref } from 'vue';
+
+    interface ActivityForm {
+        name: string;
+        description: string;
+        status: 'To Do' | 'In Progress' | 'Done' | '';
+    }
+
+    interface ApiErrorResponse {
+        errors: Record<string, string[]>;
+    }
+
+    // Define a type for API success response
+    interface ApiSuccessResponse {
+        user: {
+            id: number;
+            name: string;
+            description: string;
+            status: string;
+        };
+    }
+
+    // Form data with initial values
+    const form = ref<ActivityForm>({
+        name: '',
+        description: '',
+        status: '',
+    });
+
+    // State for error and success messages
+    const error = ref<string | null>(null);
+    const successMessage = ref<string | null>(null);
+
+    // Function to submit the form data using fetch
+    const submitForm = async (): Promise<void> => {
+        try {
+            error.value = null;
+            successMessage.value = null;
+
+            // Send POST request using fetch
+            const response = await fetch('http://discover-73-api.test/api/activity-groups', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json',
+                },
+                body: JSON.stringify(form.value),
+            });
+
+            if (!response.ok) {
+                const errorData: ApiErrorResponse = await response.json();
+                if (errorData.errors) {
+                    error.value = Object.values(errorData.errors).flat().join(', ');
+                } else {
+                    error.value = 'An error occurred while creating the activity group.';
+                }
+            } else {
+                const data: ApiSuccessResponse = await response.json();
+                successMessage.value = 'Activity Group created successfully!';
+
+                form.value = {
+                    name: '',
+                    description: '',
+                    status: '',
+                };
+            }
+        } catch (err) {
+            error.value = 'An error occurred while creating the activity group.';
+            console.error(err);
+        }
+    };
+</script>


### PR DESCRIPTION
# [D73-12] | Install a base Nuxt application
- Epic: [D73-16]

## Work
Create an Activity Group form, send the data to the API, and display whether the activity group has been sent successfully or if there are any errors.

## Testing
- Visit http://localhost:3000/

### Acceptance Criteria 1 
**WHEN** I view the base application page
**THEN** there is a form to create an activity group, with inputs for `name`, `description` and `status`.

### Acceptance Criteria 2
**WHEN** I input correct data into the form
**AND** I click the `Create Activity Group` button
**THEN** the data is stored in the database, and a success message is displayed.

### Acceptance Criteria 3
**WHEN** I input incorrect data into the form (i.e. missing name, wrong status)
**AND** I click the `Create Activity Group` button
**THEN** the an error message is displayed, with the specific errors.

[D73-12]: https://rheannemcintosh.atlassian.net/browse/D73-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D73-16]: https://rheannemcintosh.atlassian.net/browse/D73-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ