### PR TITLE
D73-14 | Allow activity groups to be deleted

### DIFF
--- a/components/ActivityGroups.vue
+++ b/components/ActivityGroups.vue
@@ -13,12 +13,35 @@ onMounted(async () => {
         error.value = (err as Error).message;
     }
 });
+
+// Function to delete an activity group
+const deleteActivityGroup = async (id: number) => {
+    try {
+        // Send DELETE request to the API
+        const response = await fetch(`http://discover-73-api.test/api/activity-groups/${id}`, {
+            method: 'DELETE',
+            headers: {
+                'Accept': 'application/json',
+            },
+        });
+
+        if (!response.ok) {
+            throw new Error('Failed to delete the activity group');
+        }
+
+        // Remove the deleted activity group from the activityGroups array
+        activityGroups.value = activityGroups.value.filter(group => group.id !== id);
+    } catch (err) {
+        error.value = (err as Error).message;
+    }
+};
 </script>
 
 <template>
     <div>
         <h1>Activity Groups</h1>
-        <div v-for="group in activityGroups">
+        <div v-if="error" class="error">{{ error }}</div>
+        <div v-for="group in activityGroups" :key="group.id">
             <ul>
                 <li>
                     <strong>ID: </strong>
@@ -26,26 +49,23 @@ onMounted(async () => {
                 </li>
                 <li>
                     <strong>Activity Group: </strong>
-                    {{group.name}}
+                    {{ group.name }}
                 </li>
                 <li>
                     <strong>Description:</strong>
                     {{ group.description }}
                 </li>
                 <li>
-                    <strong>Status</strong>
+                    <strong>Status:</strong>
                     {{ group.status }}
+                </li>
+                <li>
+                    <!-- Delete button for each activity group -->
+                    <button @click="deleteActivityGroup(group.id)">Delete</button>
                 </li>
                 <hr>
             </ul>
         </div>
     </div>
 </template>
-
-
-
-
-
-
-
 


### PR DESCRIPTION
# [D73-14] | Delete an Activity Group
- Epic: [D73-16]

## Work
Display a `Delete` button against all activity groups, and send a call to the API to DELETE the activity group.

## Testing
- Visit http://localhost:3000/

### Acceptance Criteria 2
**WHEN** I view the base application page
**AND** I click the Delete button beside an activity group
**THEN** the activity group is deleted from the database.

[D73-14]: https://rheannemcintosh.atlassian.net/browse/D73-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[D73-16]: https://rheannemcintosh.atlassian.net/browse/D73-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ